### PR TITLE
Add Optuna tuning support to classification script

### DIFF
--- a/多卡微调RETFound应用于回归任务.py
+++ b/多卡微调RETFound应用于回归任务.py
@@ -1,0 +1,997 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Multi-task regression training script (EfficientNet-B4 + TabTransformer-style head)
+- Fixes LRD (layer-wise LR decay) for non-ResNet backbones by providing a generic
+  param_groups_lrd() in-script (no reliance on util/lr_decay.py having layer1..4).
+- Correctly applies per-group learning-rate scaling AFTER optimizer creation.
+- Keeps your requested targets: tc, ldl, hdl, tg, apoa, apob.
+- Adds R2 / Pearson R metrics; macro R2 used for model selection.
+- Includes clean DDP teardown to avoid NCCL warnings on crash/exit.
+"""
+
+import argparse
+import datetime
+import json
+import os
+import time
+from pathlib import Path
+import warnings
+import faulthandler
+from contextlib import nullcontext
+from typing import Dict, Iterable, List, Optional, Tuple
+import re
+
+import numpy as np
+import pandas as pd
+from PIL import Image
+from scipy.stats import pearsonr
+
+import torch
+import torch.backends.cudnn as cudnn
+import torch.nn as nn
+from torch.utils.tensorboard import SummaryWriter
+from torch.utils.data import Dataset
+from torch.utils.data.sampler import RandomSampler, SequentialSampler
+from torch.utils.data.distributed import DistributedSampler
+from timm.models.layers import trunc_normal_
+from timm.data import create_transform
+import timm
+
+try:
+    import optuna
+except ImportError:  # pragma: no cover - optuna is optional at runtime
+    optuna = None
+
+# project utils (unchanged)
+import util.misc as misc
+from util.misc import NativeScalerWithGradNormCount as NativeScaler
+
+from tqdm import tqdm
+faulthandler.enable()
+warnings.simplefilter(action="ignore", category=FutureWarning)
+
+# =========================
+# AMP helper
+# =========================
+def autocast_context(enabled=True, dtype=torch.bfloat16):
+    if enabled and torch.cuda.is_available():
+        return torch.autocast(device_type="cuda", dtype=dtype)
+    return nullcontext()
+
+# =========================
+# Generic Layer-wise LR Decay (LRD) for diverse backbones
+# Replaces util/lr_decay.py ResNet-only logic.
+# =========================
+_DECAY_EXCLUDES = ("bias", "bn", "norm", "ln", "embedding")
+
+def _is_no_weight_decay(name: str, param: nn.Parameter, extra_nowd: Iterable[str]) -> bool:
+    if param.ndim == 1:  # norm/bn/scale weights
+        return True
+    lname = name.lower()
+    if lname.endswith(".bias"):
+        return True
+    if any(k in lname for k in _DECAY_EXCLUDES):
+        return True
+    if extra_nowd and name in set(extra_nowd):
+        return True
+    return False
+
+
+def _count_attr_len(obj, attr: str) -> int:
+    m = getattr(obj, attr, None)
+    if m is None:
+        return 0
+    try:
+        return len(m)
+    except TypeError:
+        return 0
+
+
+def _infer_layering(model: nn.Module) -> Tuple[int, List[Tuple[re.Pattern, int]]]:
+    """
+    Returns (num_layers, rules). Rules are [(regex, base_id)] mapping module name -> layer id.
+    Top/head gets layer_id = num_layers-1; stem gets 0.
+    Handles RegressionModel(backbone, head) with various backbones (ViT blocks, EfficientNet blocks, ConvNeXt stages, ResNet layer1..4).
+    """
+    back = getattr(model, "backbone", model)
+
+    # ViT/MAE-style blocks
+    n_blocks = _count_attr_len(back, "blocks")
+    if n_blocks > 0:
+        num_layers = n_blocks + 1  # + head
+        rules = [
+            (re.compile(r"(?:^|\.)(?:backbone\.)?blocks\.(\d+)\."), 1),
+        ]
+        return num_layers, rules
+
+    # ConvNeXt-style stages
+    n_stages = _count_attr_len(back, "stages")
+    if n_stages > 0:
+        num_layers = n_stages + 1
+        rules = [
+            (re.compile(r"(?:^|\.)(?:backbone\.)?stages\.(\d+)\."), 1),
+        ]
+        return num_layers, rules
+
+    # EfficientNet/MBConv blocks (Sequential)
+    n_blocks2 = _count_attr_len(back, "blocks")
+    if n_blocks2 > 0:
+        num_layers = n_blocks2 + 1
+        rules = [
+            (re.compile(r"(?:^|\.)(?:backbone\.)?blocks\.(\d+)\."), 1),
+        ]
+        return num_layers, rules
+
+    # ResNet layer1..layer4
+    if all(hasattr(back, f"layer{i}") for i in range(1, 5)):
+        num_layers = 4 + 1
+        rules = [
+            (re.compile(r"(?:^|\.)(?:backbone\.)?layer1\."), 1),
+            (re.compile(r"(?:^|\.)(?:backbone\.)?layer2\."), 2),
+            (re.compile(r"(?:^|\.)(?:backbone\.)?layer3\."), 3),
+            (re.compile(r"(?:^|\.)(?:backbone\.)?layer4\."), 4),
+        ]
+        return num_layers, rules
+
+    # Fallback: single layer
+    return 1, []
+
+
+def _get_layer_id(name: str, num_layers: int, rules: List[Tuple[re.Pattern, int]]) -> int:
+    lname = name.lower()
+    # heads
+    if ".head." in lname or lname.startswith("head."):
+        return max(0, num_layers - 1)
+    if ".regression_head." in lname or lname.startswith("regression_head."):
+        return max(0, num_layers - 1)
+    if ".classifier." in lname or lname.startswith("classifier."):
+        return max(0, num_layers - 1)
+
+    # match rules
+    for pat, base in rules:
+        m = pat.search(name)
+        if m:
+            if m.groups():
+                try:
+                    idx = int(m.group(1))
+                    return min(base + idx, max(0, num_layers - 1))
+                except Exception:
+                    return base
+            return base
+
+    return 0
+
+
+def param_groups_lrd(
+    model: nn.Module,
+    weight_decay: float = 0.05,
+    no_weight_decay_list: Iterable[str] = (),
+    layer_decay: float = 1.0,
+):
+    """Generic LLRD param grouping.
+    Returns groups with 'lr_scale' populated; set actual lr via `pg['lr'] = base_lr * lr_scale` after optimizer creation.
+    """
+    num_layers, rules = _infer_layering(model)
+    if num_layers < 1:
+        num_layers = 1
+
+    layer_scales = [layer_decay ** (num_layers - 1 - i) for i in range(num_layers)]
+
+    buckets: Dict[Tuple[int, bool], Dict] = {}
+    for name, p in model.named_parameters():
+        if not p.requires_grad:
+            continue
+        layer_id = _get_layer_id(name, num_layers, rules)
+        is_no_decay = _is_no_weight_decay(name, p, no_weight_decay_list)
+        key = (layer_id, is_no_decay)
+        if key not in buckets:
+            buckets[key] = {
+                "params": [],
+                "weight_decay": 0.0 if is_no_decay else weight_decay,
+                "lr_scale": layer_scales[layer_id],
+            }
+        buckets[key]["params"].append(p)
+
+    groups = [g for g in buckets.values() if len(g["params"]) > 0]
+    if not groups:  # extreme fallback
+        all_params = [p for _, p in model.named_parameters() if p.requires_grad]
+        groups = [{"params": all_params, "weight_decay": weight_decay, "lr_scale": 1.0}]
+    return groups
+
+# =========================
+# TabTransformer-style Multi-task head
+# =========================
+class MultiTaskTabTransformerHead(nn.Module):
+    def __init__(
+        self,
+        in_dim: int,
+        num_tasks: int,
+        embed_dim: int = None,
+        depth: int = 2,
+        num_heads: int = 4,
+        mlp_ratio: float = 2.0,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        embed_dim = embed_dim or in_dim
+        self.num_tasks = num_tasks
+
+        self.proj = nn.Linear(in_dim, embed_dim)
+        self.task_tokens = nn.Parameter(torch.zeros(num_tasks, embed_dim))  # [T, E]
+        trunc_normal_(self.task_tokens, std=0.02)
+
+        enc_layer = nn.TransformerEncoderLayer(
+            d_model=embed_dim,
+            nhead=num_heads,
+            dim_feedforward=int(embed_dim * mlp_ratio),
+            activation="gelu",
+            dropout=dropout,
+            batch_first=True,
+            norm_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(enc_layer, num_layers=depth)
+        self.norm = nn.LayerNorm(embed_dim)
+        self.head = nn.Linear(embed_dim, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [B, in_dim]
+        x = self.proj(x)  # [B, E]
+        tokens = x.unsqueeze(1) + self.task_tokens.unsqueeze(0)  # [B, T, E]
+        z = self.encoder(tokens)  # [B, T, E]
+        z = self.norm(z)
+        y = self.head(z).squeeze(-1)  # [B, T]
+        return y
+
+
+# =========================
+# CSV Dataset (multi-task regression)
+# =========================
+class CSVDatasetRegression(Dataset):
+    def __init__(
+        self,
+        csv_file,
+        split,
+        path_col="path",
+        split_col="split",
+        targets=("tc", "ldl", "hdl", "tg", "apoa", "apob"),
+        transform=None,
+        dropna=True,
+    ):
+        self.transform = transform
+        self.path_col = path_col
+        self.split_col = split_col
+        self.targets = list(targets)
+
+        df = pd.read_csv(csv_file)
+        df = df[df[split_col].astype(str).str.lower() == str(split).lower()].copy()
+
+        df[path_col] = df[path_col].astype(str)
+        df["__exists__"] = df[path_col].apply(lambda p: Path(p).is_file())
+        missing = (~df["__exists__"]).sum()
+        if missing > 0:
+            print(f"[WARN] {missing} files not found; dropped. Example: "
+                  f"{df.loc[~df['__exists__'], path_col].head(3).tolist()}")
+        df = df[df["__exists__"]].copy()
+
+        missing_cols = [c for c in self.targets if c not in df.columns]
+        if len(missing_cols) > 0:
+            raise ValueError(f"CSV 缺少目标列: {missing_cols}")
+        cols = [path_col] + self.targets
+        df = df[cols].copy()
+
+        if dropna:
+            before = len(df)
+            df = df.dropna(subset=self.targets, how="any").copy()
+            after = len(df)
+            if before != after:
+                print(f"[INFO] Dropped {before - after} rows due to NaN in targets.")
+
+        self.samples = []
+        for _, r in df.iterrows():
+            y = [float(r[c]) for c in self.targets]
+            self.samples.append((r[path_col], np.array(y, dtype=np.float32)))
+
+        self._report_stats(df)
+
+    def _report_stats(self, df):
+        print(f"[INFO] Loaded {len(self.samples)} samples for split.")
+        desc = df[self.targets].describe().T
+        fields = ["mean", "std", "min", "max"]
+        print("[INFO] Target stats (per split):")
+        for t in self.targets:
+            vals = {k: float(desc.loc[t, k]) for k in fields}
+            print(f"  - {t:>5s}: mean={vals['mean']:.4f}, std={vals['std']:.4f}, min={vals['min']:.4f}, max={vals['max']:.4f}")
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, idx):
+        path, target = self.samples[idx]
+        with Image.open(path) as img:
+            img = img.convert("RGB")
+        if self.transform is not None:
+            img = self.transform(img)
+        return img, torch.from_numpy(target)
+
+
+def build_transforms(args):
+    mean, std = (0.485, 0.456, 0.406), (0.229, 0.224, 0.225)
+    train_tf = create_transform(
+        input_size=args.input_size, is_training=True,
+        color_jitter=args.color_jitter,
+        auto_augment=args.aa if args.aa and args.aa.lower() != "none" else None,
+        interpolation="bicubic",
+        re_prob=args.reprob, re_mode=args.remode, re_count=args.recount,
+        mean=mean, std=std,
+    )
+    eval_tf = create_transform(
+        input_size=args.input_size, is_training=False,
+        interpolation="bicubic", mean=mean, std=std,
+    )
+    return train_tf, eval_tf
+
+
+# =========================
+# Train one epoch
+# =========================
+def train_one_epoch(
+    model, criterion, data_loader, optimizer, device, epoch, loss_scaler,
+    clip_grad=None, log_writer=None, args=None
+):
+    model.train(True)
+    header = f"Epoch[{epoch}]"
+    num_steps = len(data_loader)
+    running_loss = 0.0
+
+    optimizer.zero_grad(set_to_none=True)
+    accum_iter = max(1, int(args.accum_iter))
+
+    if isinstance(getattr(data_loader, "sampler", None), DistributedSampler):
+        data_loader.sampler.set_epoch(epoch)
+
+    for step, (images, targets) in enumerate(data_loader):
+        images = images.to(device, non_blocking=True)
+        targets = targets.to(device, non_blocking=True)
+
+        with autocast_context(enabled=True, dtype=torch.bfloat16):
+            outputs = model(images)
+            loss = criterion(outputs, targets) / accum_iter
+
+        loss_value = loss.item() * accum_iter
+        running_loss += loss_value
+
+        grad_update = ((step + 1) % accum_iter == 0) or (step + 1 == num_steps)
+        loss_scaler(
+            loss, optimizer, clip_grad=clip_grad, parameters=model.parameters(),
+            create_graph=False, update_grad=grad_update
+        )
+        if grad_update:
+            optimizer.zero_grad(set_to_none=True)
+
+        if (step % 50 == 0) or (step + 1 == num_steps):
+            lr = optimizer.param_groups[0]["lr"]
+            if misc.is_main_process():
+                print(f"{header} [{step+1:>5d}/{num_steps}] loss={loss_value:.4f} lr={lr:.2e}")
+
+    epoch_loss = running_loss / max(1, num_steps)
+    if log_writer is not None and misc.is_main_process():
+        log_writer.add_scalar("loss/train", epoch_loss, epoch)
+        log_writer.add_scalar("lr", optimizer.param_groups[0]["lr"], epoch)
+    return {"loss": epoch_loss}
+
+
+# =========================
+# Evaluation (MAE/RMSE/R2/PearsonR)
+# =========================
+@torch.no_grad()
+def evaluate_regression(
+    data_loader, model, device, args, epoch, mode="val", num_tasks=6, target_names=None, log_writer=None
+):
+    model.eval()
+    crit_mse = nn.MSELoss(reduction="none")
+
+    all_pred, all_true = [], []
+    total_loss, n_batches = 0.0, 0
+
+    for images, targets in data_loader:
+        images = images.to(device, non_blocking=True)
+        targets = targets.to(device, non_blocking=True)
+        with autocast_context(enabled=True, dtype=torch.bfloat16):
+            outputs = model(images)
+        batch_mse = crit_mse(outputs, targets).mean(dim=0)
+        total_loss += batch_mse.mean().item()
+        n_batches += 1
+        all_pred.append(outputs.detach().float().cpu())
+        all_true.append(targets.detach().float().cpu())
+
+    if n_batches == 0:
+        return {"loss": 0.0}, 0.0
+
+    y_pred = torch.cat(all_pred, dim=0).numpy()
+    y_true = torch.cat(all_true, dim=0).numpy()
+
+    mae = np.mean(np.abs(y_pred - y_true), axis=0)
+    rmse = np.sqrt(np.mean((y_pred - y_true) ** 2, axis=0))
+    r2, pr = [], []
+    for t in range(y_true.shape[1]):
+        y, yhat = y_true[:, t], y_pred[:, t]
+        ss_res = np.sum((y - yhat) ** 2)
+        ss_tot = np.sum((y - np.mean(y)) ** 2) + 1e-12
+        r2.append(1.0 - ss_res / ss_tot)
+        pr.append(pearsonr(y, yhat)[0])
+    r2 = np.array(r2)
+    pr = np.array(pr)
+    macro_r2 = float(np.mean(r2))
+    macro_pr = float(np.mean(pr))
+
+    names = target_names or [f"t{idx}" for idx in range(num_tasks)]
+    if misc.is_main_process():
+        print(f"[{mode.upper()}][epoch={epoch}] macro_R2={macro_r2:.4f} macro_PearsonR={macro_pr:.4f} "
+              f"(loss_mse={total_loss/n_batches:.4f})")
+        for n, a, rm, s, p in zip(names, mae, rmse, r2, pr):
+            print(f"  - {n:>5s}: MAE={a:.4f} RMSE={rm:.4f} R2={s:.4f} PearsonR={p:.4f}")
+
+    if log_writer is not None and misc.is_main_process():
+        log_writer.add_scalar(f"loss/{mode}_mse", total_loss / n_batches, epoch)
+        log_writer.add_scalar(f"{mode}/macro_R2", macro_r2, epoch)
+        log_writer.add_scalar(f"{mode}/macro_PearsonR", macro_pr, epoch)
+        for i, n in enumerate(names):
+            log_writer.add_scalar(f"{mode}/MAE_{n}", mae[i], epoch)
+            log_writer.add_scalar(f"{mode}/RMSE_{n}", rmse[i], epoch)
+            log_writer.add_scalar(f"{mode}/R2_{n}", r2[i], epoch)
+            log_writer.add_scalar(f"{mode}/PearsonR_{n}", pr[i], epoch)
+
+    return {"loss": total_loss / n_batches}, macro_r2
+
+
+# =========================
+# Arg parser
+# =========================
+def get_args_parser():
+    parser = argparse.ArgumentParser(
+        "EfficientNet-B4 fine-tuning -> Multi-task Regression (CSV with absolute paths)", add_help=False
+    )
+    parser.add_argument("--batch_size", default=64, type=int)
+    parser.add_argument("--epochs", default=30, type=int)
+    parser.add_argument("--accum_iter", default=2, type=int)
+
+    # Model
+    parser.add_argument("--model", default="efficientnet_b4", type=str)
+    parser.add_argument("--input_size", default=380, type=int)
+    parser.add_argument("--drop_path", type=float, default=0.2)
+    parser.add_argument("--pretrained", action="store_true", default=True)
+    parser.add_argument("--head_embed_dim", type=int, default=None)
+    parser.add_argument("--head_depth", type=int, default=2)
+    parser.add_argument("--head_num_heads", type=int, default=4)
+    parser.add_argument("--head_mlp_ratio", type=float, default=2.0)
+    parser.add_argument("--head_dropout", type=float, default=0.1)
+
+    # Optim / schedule
+    parser.add_argument("--clip_grad", type=float, default=None)
+    parser.add_argument("--weight_decay", type=float, default=0.05)
+    parser.add_argument("--lr", type=float, default=None)
+    parser.add_argument("--blr", type=float, default=2e-3)
+    parser.add_argument("--layer_decay", type=float, default=0.65)
+    parser.add_argument("--min_lr", type=float, default=1e-6)
+    parser.add_argument("--warmup_epochs", type=int, default=5)
+    parser.add_argument("--huber_beta", type=float, default=1.0)
+
+    # Aug
+    parser.add_argument("--color_jitter", type=float, default=None)
+    parser.add_argument("--aa", type=str, default="rand-m9-mstd0.5-inc1")
+    parser.add_argument("--reprob", type=float, default=0.25)
+    parser.add_argument("--remode", type=str, default="pixel")
+    parser.add_argument("--recount", type=int, default=1)
+
+    # Finetune
+    parser.add_argument("--finetune", default="", type=str)
+    parser.add_argument("--task", default="efficientnet_b4_regression", type=str)
+    parser.add_argument("--adaptation", default="finetune", choices=["finetune", "lp"])
+
+    # CSV columns
+    parser.add_argument("--csv_file", type=str, required=True)
+    parser.add_argument("--path_col", type=str, default="path")
+    parser.add_argument("--split_col", type=str, default="split")
+
+    parser.add_argument(
+        "--targets", nargs="+",
+        default=["tc", "ldl", "hdl", "tg", "apoa", "apob"],
+        help="regression targets to extract from CSV"
+    )
+
+    # Runtime & IO
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--seed", default=0, type=int)
+    parser.add_argument("--resume", default="")
+    parser.add_argument("--start_epoch", default=0, type=int)
+    parser.add_argument("--eval", action="store_true")
+    parser.add_argument("--num_workers", default=8, type=int)
+    parser.add_argument("--pin_mem", action="store_true"); parser.set_defaults(pin_mem=True)
+    parser.add_argument("--output_dir", default="./output_dir")
+    parser.add_argument("--log_dir", default="./output_logs")
+    parser.add_argument("--savemodel", action="store_true", default=True)
+
+    # Optuna hyper-parameter search
+    parser.add_argument("--optuna_trials", type=int, default=0,
+                        help="number of Optuna trials to run; 0 disables tuning")
+    parser.add_argument("--optuna_timeout", type=int, default=None,
+                        help="maximum search time in seconds")
+    parser.add_argument("--optuna_direction", type=str, default="maximize",
+                        choices=["maximize", "minimize"],
+                        help="direction for Optuna study")
+    parser.add_argument("--optuna_storage", type=str, default=None,
+                        help="Optuna storage URL for persistent studies")
+    parser.add_argument("--optuna_study_name", type=str, default=None,
+                        help="name of the Optuna study")
+    parser.add_argument("--optuna_resume", action="store_true", default=False,
+                        help="resume Optuna study if it exists")
+    parser.add_argument("--optuna_seed", type=int, default=None,
+                        help="random seed for Optuna sampler")
+    parser.add_argument("--optuna_pruner", type=str, default="none",
+                        choices=["none", "median"],
+                        help="pruning strategy for Optuna trials")
+    parser.add_argument("--optuna_epochs", type=int, default=None,
+                        help="override training epochs during Optuna search")
+    parser.add_argument("--optuna_eval_test", action="store_true", default=False,
+                        help="run test evaluation inside Optuna trials")
+    parser.add_argument("--optuna_n_jobs", type=int, default=1,
+                        help="number of parallel Optuna workers")
+    parser.add_argument("--optuna_sampler", type=str, default="tpe",
+                        choices=["tpe", "random"],
+                        help="Optuna sampler to use")
+
+    # Distributed
+    parser.add_argument("--world_size", default=1, type=int)
+    parser.add_argument("--local_rank", default=-1, type=int)
+    parser.add_argument("--dist_on_itp", action="store_true")
+    parser.add_argument("--dist_url", default="env://")
+    parser.add_argument("--dist_eval", action="store_true", default=False)
+
+    # Normalization preset (kept for compatibility)
+    parser.add_argument("--norm", default="IMAGENET", type=str)
+
+    return parser
+
+
+# =========================
+# Main utilities
+# =========================
+def _clone_args(args: argparse.Namespace) -> argparse.Namespace:
+    return argparse.Namespace(**vars(args))
+
+
+def run_experiment(args: argparse.Namespace, trial: Optional["optuna.trial.Trial"] = None) -> float:
+    misc.init_distributed_mode(args)
+    device = torch.device(args.device)
+
+    if misc.is_main_process():
+        print(f"job dir: {os.path.dirname(os.path.realpath(__file__))}")
+        print(f"{args}".replace(", ", ",\n"))
+        if trial is not None:
+            print(f"[Optuna] Running trial #{trial.number}")
+
+    if args.distributed and torch.cuda.is_available():
+        torch.cuda.set_device(args.gpu)
+
+    torch.manual_seed(args.seed + misc.get_rank())
+    np.random.seed(args.seed + misc.get_rank())
+    cudnn.benchmark = True
+
+    start_time = time.time()
+    max_score, best_epoch = -1e9, 0
+
+    try:
+        # Data
+        train_tf, eval_tf = build_transforms(args)
+        dataset_train = CSVDatasetRegression(
+            args.csv_file, split="train",
+            path_col=args.path_col, split_col=args.split_col,
+            targets=args.targets, transform=train_tf, dropna=True
+        )
+        dataset_val = CSVDatasetRegression(
+            args.csv_file, split="iv",
+            path_col=args.path_col, split_col=args.split_col,
+            targets=args.targets, transform=eval_tf, dropna=True
+        )
+        dataset_test = CSVDatasetRegression(
+            args.csv_file, split="ev",
+            path_col=args.path_col, split_col=args.split_col,
+            targets=args.targets, transform=eval_tf, dropna=True
+        )
+        num_tasks = len(args.targets)
+
+        # Model
+        if misc.is_main_process():
+            print(f"[Model] Creating {args.model} with pretrained={args.pretrained}")
+        backbone = timm.create_model(
+            args.model,
+            pretrained=args.pretrained,
+            num_classes=0,
+            drop_path_rate=args.drop_path,
+        )
+        feat_dim = backbone.num_features
+        if misc.is_main_process():
+            print(f"[Model] Feature dimension: {feat_dim}")
+
+        if args.finetune and os.path.isfile(args.finetune):
+            if misc.is_main_process():
+                print(f"[Load Checkpoint] {args.finetune}")
+            checkpoint = torch.load(args.finetune, map_location="cpu")
+            checkpoint_model = checkpoint.get("model", checkpoint)
+            backbone.load_state_dict(checkpoint_model, strict=False)
+
+        head_embed_dim = args.head_embed_dim or feat_dim
+        if head_embed_dim % args.head_num_heads != 0:
+            raise ValueError(
+                f"head_embed_dim ({head_embed_dim}) must be divisible by head_num_heads ({args.head_num_heads})"
+            )
+
+        regression_head = MultiTaskTabTransformerHead(
+            in_dim=feat_dim,
+            num_tasks=num_tasks,
+            embed_dim=head_embed_dim,
+            depth=args.head_depth,
+            num_heads=args.head_num_heads,
+            mlp_ratio=args.head_mlp_ratio,
+            dropout=args.head_dropout,
+        )
+        for m in regression_head.modules():
+            if isinstance(m, nn.Linear):
+                trunc_normal_(m.weight, std=0.02)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+
+        class RegressionModel(nn.Module):
+            def __init__(self, backbone, head):
+                super().__init__()
+                self.backbone = backbone
+                self.head = head
+
+            def forward(self, x):
+                features = self.backbone(x)
+                return self.head(features)
+
+            def no_weight_decay(self):
+                if hasattr(self.backbone, "no_weight_decay"):
+                    return {"backbone." + k for k in self.backbone.no_weight_decay()}
+                return set()
+
+        model = RegressionModel(backbone, regression_head)
+
+        # DDP
+        model.to(device)
+        model_without_ddp = model
+        if args.distributed:
+            ddp_kwargs = dict(broadcast_buffers=False)
+            if args.adaptation == "lp":
+                ddp_kwargs["find_unused_parameters"] = True
+            model = torch.nn.parallel.DistributedDataParallel(
+                model, device_ids=[args.gpu] if torch.cuda.is_available() else None, **ddp_kwargs
+            )
+            model_without_ddp = model.module
+
+        # Samplers/Loaders
+        if args.distributed:
+            sampler_train = DistributedSampler(
+                dataset_train, num_replicas=misc.get_world_size(), rank=misc.get_rank(), shuffle=True
+            )
+            if misc.is_main_process():
+                print("[INFO] Using DistributedSampler for training")
+            if args.dist_eval:
+                sampler_val = DistributedSampler(dataset_val, shuffle=False)
+                sampler_test = DistributedSampler(dataset_test, shuffle=False)
+            else:
+                sampler_val = SequentialSampler(dataset_val)
+                sampler_test = SequentialSampler(dataset_test)
+        else:
+            sampler_train = RandomSampler(dataset_train)
+            sampler_val = SequentialSampler(dataset_val)
+            sampler_test = SequentialSampler(dataset_test)
+
+        log_writer = None
+        if misc.is_main_process() and (not args.eval) and args.log_dir:
+            os.makedirs(args.log_dir, exist_ok=True)
+            log_suffix = args.task if trial is None else f"{args.task}"
+            log_writer = SummaryWriter(log_dir=os.path.join(args.log_dir, log_suffix))
+
+        data_loader_train = torch.utils.data.DataLoader(
+            dataset_train, sampler=sampler_train, batch_size=args.batch_size,
+            num_workers=args.num_workers, pin_memory=args.pin_mem, drop_last=True
+        )
+        if misc.is_main_process():
+            print(f"[INFO] len(train_set)={len(dataset_train)} (batches: {len(data_loader_train)})")
+        data_loader_val = torch.utils.data.DataLoader(
+            dataset_val, sampler=sampler_val, batch_size=args.batch_size,
+            num_workers=args.num_workers, pin_memory=args.pin_mem, drop_last=False
+        )
+        data_loader_test = torch.utils.data.DataLoader(
+            dataset_test, sampler=sampler_test, batch_size=args.batch_size,
+            num_workers=args.num_workers, pin_memory=args.pin_mem, drop_last=False
+        )
+
+        # Loss
+        criterion = nn.SmoothL1Loss(beta=args.huber_beta)
+
+        # Eval-only resume
+        if args.resume and args.eval:
+            checkpoint = torch.load(args.resume, map_location="cpu")
+            if misc.is_main_process():
+                print(f"[Eval] Load checkpoint: {args.resume}")
+            model_without_ddp.load_state_dict(checkpoint["model"], strict=False)
+
+        # Adaptation
+        if args.adaptation == "lp":
+            for name, p in model_without_ddp.named_parameters():
+                p.requires_grad = ("head" in name)
+            if misc.is_main_process():
+                print("[Adaptation] Linear probe: train head only.")
+        else:
+            if misc.is_main_process():
+                print("[Adaptation] Full finetune.")
+
+        n_parameters = sum(p.numel() for p in model_without_ddp.parameters() if p.requires_grad)
+        if misc.is_main_process():
+            print(f"[INFO] Trainable params (M): {n_parameters/1e6:.2f}")
+
+        # LR schedule
+        world_size = misc.get_world_size()
+        eff_bs = args.batch_size * args.accum_iter * world_size
+        if args.lr is None:
+            args.lr = args.blr * eff_bs / 256
+        if misc.is_main_process():
+            print(
+                f"base lr: {args.blr:.2e}  actual lr: {args.lr:.2e}  accum_iter: {args.accum_iter}  "
+                f"world_size: {world_size}  eff_bs: {eff_bs}"
+            )
+
+        # Optimizer groups with LLRD
+        no_weight_decay = (
+            model_without_ddp.no_weight_decay() if hasattr(model_without_ddp, "no_weight_decay") else []
+        )
+        param_groups = param_groups_lrd(
+            model_without_ddp, weight_decay=args.weight_decay,
+            no_weight_decay_list=no_weight_decay, layer_decay=args.layer_decay,
+        )
+        for g in param_groups:
+            g["params"] = [p for p in g["params"] if p.requires_grad]
+        optimizer = torch.optim.AdamW(param_groups, lr=args.lr)
+        # Apply per-group lr scales
+        for pg in optimizer.param_groups:
+            scale = pg.get("lr_scale", 1.0)
+            pg["lr"] = args.lr * scale
+
+        loss_scaler = NativeScaler()
+        if misc.is_main_process():
+            print(f"criterion = {criterion}")
+
+        # (optional) restore training state
+        misc.load_model(args=args, model_without_ddp=model_without_ddp,
+                        optimizer=optimizer, loss_scaler=loss_scaler)
+
+        # Eval only path
+        if args.eval:
+            _val_stats, _val_r2 = evaluate_regression(
+                data_loader_test, model, device, args, epoch=0, mode="test",
+                num_tasks=num_tasks, target_names=args.targets, log_writer=log_writer
+            )
+            if log_writer is not None:
+                log_writer.flush()
+                log_writer.close()
+            return _val_r2
+
+        if misc.is_main_process():
+            desc = f"Trial {trial.number}" if trial is not None else "Epochs"
+            epoch_iter = tqdm(range(args.start_epoch, args.epochs), desc=desc)
+        else:
+            epoch_iter = range(args.start_epoch, args.epochs)
+
+        for epoch in epoch_iter:
+            train_stats = train_one_epoch(
+                model, criterion, data_loader_train,
+                optimizer, device, epoch, loss_scaler,
+                clip_grad=args.clip_grad, log_writer=log_writer, args=args
+            )
+
+            if epoch % 2 == 0:
+                _, _ = evaluate_regression(
+                    data_loader_train, model, device, args, epoch, mode="train",
+                    num_tasks=num_tasks, target_names=args.targets, log_writer=log_writer
+                )
+
+            val_stats, val_score = evaluate_regression(
+                data_loader_val, model, device, args, epoch, mode="val",
+                num_tasks=num_tasks, target_names=args.targets, log_writer=log_writer
+            )
+
+            if trial is not None:
+                trial.report(val_score, epoch)
+                if trial.should_prune():
+                    if log_writer is not None:
+                        log_writer.flush()
+                        log_writer.close()
+                    raise optuna.TrialPruned()  # type: ignore[misc]
+
+            if misc.is_main_process():
+                if max_score < val_score:
+                    max_score = val_score
+                    best_epoch = epoch
+                    if args.output_dir and args.savemodel:
+                        misc.save_model(
+                            args=args, model=model, model_without_ddp=model_without_ddp,
+                            optimizer=optimizer, loss_scaler=loss_scaler, epoch=epoch, mode="best"
+                        )
+                print(f"[VAL] Best epoch={best_epoch}, Best macro_R2={max_score:.4f}")
+
+                if log_writer is not None:
+                    log_writer.add_scalar("loss/val_epoch_mse", val_stats["loss"], epoch)
+                    log_writer.flush()
+
+                log_stats = {**{f"train_{k}": v for k, v in train_stats.items()},
+                             "epoch": epoch, "n_parameters": n_parameters}
+                if args.output_dir:
+                    os.makedirs(os.path.join(args.output_dir, args.task), exist_ok=True)
+                    with open(os.path.join(args.output_dir, args.task, "log.txt"), "a", encoding="utf-8") as f:
+                        f.write(json.dumps(log_stats) + "\n")
+
+            if args.distributed:
+                torch.distributed.barrier()
+
+        if log_writer is not None:
+            log_writer.flush()
+            log_writer.close()
+
+        if trial is None:
+            ckpt_path = os.path.join(args.output_dir, args.task, "checkpoint-best.pth")
+            if args.savemodel and os.path.isfile(ckpt_path):
+                if misc.is_main_process():
+                    print(f"[TEST] Loading best checkpoint from {ckpt_path}")
+                checkpoint = torch.load(ckpt_path, map_location="cpu")
+                model_without_ddp.load_state_dict(checkpoint["model"], strict=False)
+                model.to(device)
+                if misc.is_main_process():
+                    print(f"[TEST] best epoch = {checkpoint.get('epoch', -1)}")
+            if args.distributed:
+                for p in model.parameters():
+                    torch.distributed.broadcast(p.data, src=0)
+
+            _test_stats, _test_r2 = evaluate_regression(
+                data_loader_test, model, device, args, -1, mode="test",
+                num_tasks=num_tasks, target_names=args.targets, log_writer=None
+            )
+            if misc.is_main_process():
+                total_time = time.time() - start_time
+                total_time_str = str(datetime.timedelta(seconds=int(total_time)))
+                print(f"Training time {total_time_str}")
+                print(f"[TEST] macro_R2={_test_r2:.4f}")
+        else:
+            if misc.is_main_process():
+                total_time = time.time() - start_time
+                total_time_str = str(datetime.timedelta(seconds=int(total_time)))
+                print(f"[Optuna][Trial {trial.number}] best macro_R2={max_score:.4f} (time={total_time_str})")
+
+        return max_score
+
+    finally:
+        if args.distributed and torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+def run_optuna(args: argparse.Namespace) -> None:
+    if optuna is None:
+        raise ImportError("Optuna is required for hyper-parameter tuning but is not installed.")
+
+    if args.optuna_trials <= 0:
+        raise ValueError("optuna_trials must be > 0 to start tuning")
+
+    sampler: Optional[optuna.samplers.BaseSampler]
+    if args.optuna_sampler == "random":
+        sampler = optuna.samplers.RandomSampler(seed=args.optuna_seed)
+    else:
+        sampler = optuna.samplers.TPESampler(seed=args.optuna_seed)
+
+    pruner: Optional[optuna.pruners.BasePruner] = None
+    if args.optuna_pruner == "median":
+        pruner = optuna.pruners.MedianPruner()
+
+    study_kwargs = {"direction": args.optuna_direction, "sampler": sampler}
+    if pruner is not None:
+        study_kwargs["pruner"] = pruner
+    if args.optuna_storage:
+        study_kwargs["storage"] = args.optuna_storage
+        if args.optuna_study_name:
+            study_kwargs["study_name"] = args.optuna_study_name
+        study_kwargs["load_if_exists"] = args.optuna_resume
+    elif args.optuna_study_name:
+        study_kwargs["study_name"] = args.optuna_study_name
+
+    study = optuna.create_study(**study_kwargs)
+
+    base_output = Path(args.output_dir) if args.output_dir else None
+    base_log = Path(args.log_dir) if args.log_dir else None
+    if base_output is not None:
+        base_output.mkdir(parents=True, exist_ok=True)
+    if base_log is not None:
+        base_log.mkdir(parents=True, exist_ok=True)
+
+    def objective(trial: optuna.trial.Trial) -> float:
+        trial_args = _clone_args(args)
+        trial_args.optuna_trials = 0
+        trial_args.optuna_timeout = None
+        trial_args.optuna_direction = args.optuna_direction
+        trial_args.optuna_eval_test = args.optuna_eval_test
+        trial_args.optuna_pruner = args.optuna_pruner
+        trial_args.optuna_sampler = args.optuna_sampler
+        trial_args.optuna_n_jobs = 1
+
+        # Sample hyper-parameters
+        lr = trial.suggest_float("lr", 5e-5, 5e-3, log=True)
+        weight_decay = trial.suggest_float("weight_decay", 1e-6, 0.1, log=True)
+        layer_decay = trial.suggest_float("layer_decay", 0.4, 0.95)
+        drop_path = trial.suggest_float("drop_path", 0.0, 0.4)
+        head_dropout = trial.suggest_float("head_dropout", 0.0, 0.5)
+        head_depth = trial.suggest_int("head_depth", 1, 4)
+        head_mlp_ratio = trial.suggest_float("head_mlp_ratio", 1.0, 4.0)
+        head_num_heads = trial.suggest_categorical("head_num_heads", [2, 4, 8])
+        huber_beta = trial.suggest_float("huber_beta", 0.5, 2.0)
+
+        trial_args.lr = lr
+        trial_args.blr = lr
+        trial_args.weight_decay = weight_decay
+        trial_args.layer_decay = layer_decay
+        trial_args.drop_path = drop_path
+        trial_args.head_dropout = head_dropout
+        trial_args.head_depth = head_depth
+        trial_args.head_mlp_ratio = head_mlp_ratio
+        trial_args.head_num_heads = head_num_heads
+        trial_args.huber_beta = huber_beta
+        trial_args.savemodel = bool(args.optuna_eval_test)
+        trial_args.task = f"{args.task}_trial{trial.number}"
+
+        if args.optuna_epochs is not None:
+            trial_args.epochs = args.optuna_epochs
+
+        if base_output is not None:
+            trial_args.output_dir = str(base_output)
+        if base_log is not None:
+            trial_args.log_dir = str(base_log)
+
+        trial_args.seed = (args.seed if args.seed is not None else 0) + trial.number
+
+        return run_experiment(trial_args, trial=trial)
+
+    study.optimize(
+        objective,
+        n_trials=args.optuna_trials,
+        timeout=args.optuna_timeout,
+        n_jobs=args.optuna_n_jobs,
+        gc_after_trial=True,
+    )
+
+    if misc.is_main_process():
+        print("[Optuna] Best trial:")
+        print(f"  value: {study.best_value}")
+        for key, value in study.best_trial.params.items():
+            print(f"  {key}: {value}")
+        if base_output is not None:
+            summary_path = base_output / "optuna_best.json"
+            with open(summary_path, "w", encoding="utf-8") as f:
+                json.dump({"value": study.best_value, "params": study.best_trial.params}, f, ensure_ascii=False, indent=2)
+
+
+def main(args: argparse.Namespace) -> None:
+    if args.optuna_trials and args.optuna_trials > 0:
+        run_optuna(args)
+    else:
+        if args.output_dir and (not os.path.exists(args.output_dir)):
+            Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+        if args.log_dir and (not os.path.exists(args.log_dir)):
+            Path(args.log_dir).mkdir(parents=True, exist_ok=True)
+        run_experiment(args)
+
+
+if __name__ == "__main__":
+    parsed = get_args_parser()
+    args = parsed.parse_args()
+    main(args)

--- a/微调RETFound 多卡分类任务.py
+++ b/微调RETFound 多卡分类任务.py
@@ -1,0 +1,814 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse
+import datetime
+import json
+import os
+import time
+from pathlib import Path
+import warnings
+import faulthandler
+from collections import Counter
+from contextlib import nullcontext
+
+import numpy as np
+import pandas as pd
+from PIL import Image
+from typing import Optional
+
+import torch
+import torch.backends.cudnn as cudnn
+from torch.utils.tensorboard import SummaryWriter
+from torch.utils.data import Dataset, WeightedRandomSampler
+from torch.utils.data.sampler import RandomSampler, SequentialSampler
+from torch.utils.data.distributed import DistributedSampler
+from timm.models.layers import trunc_normal_
+from timm.data import create_transform
+from timm.data.mixup import Mixup
+from timm.loss import SoftTargetCrossEntropy
+from huggingface_hub import hf_hub_download
+
+try:
+    import optuna  # type: ignore
+except ImportError:  # pragma: no cover - optuna is optional at runtime
+    optuna = None
+
+import models_vit as models
+import util.lr_decay as lrd
+import util.misc as misc
+from util.pos_embed import interpolate_pos_embed
+from util.misc import NativeScalerWithGradNormCount as NativeScaler
+from engine_finetune import evaluate  # 评估沿用原函数
+
+from tqdm import tqdm
+faulthandler.enable()
+warnings.simplefilter(action="ignore", category=FutureWarning)
+
+# =========================
+# 小工具：返回 AMP/空 上下文实例（可用于 CPU/非AMP）
+# =========================
+def autocast_context(enabled=True, dtype=torch.bfloat16):
+    if enabled and torch.cuda.is_available():
+        return torch.autocast(device_type="cuda", dtype=dtype)
+    return nullcontext()
+
+# =========================
+# CSV 数据集（直接用 path 列）
+# =========================
+class CSVDataset(Dataset):
+    def __init__(
+        self, csv_file, split, path_col="path", label_col="partition",
+        split_col="split", transform=None, ignore_unlabeled=True, class_to_idx=None
+    ):
+        """
+        split: 'train' | 'iv' | 'ev'（大小写不敏感）
+        """
+        self.transform = transform
+        self.path_col = path_col
+        self.label_col = label_col
+        self.split_col = split_col
+
+        df = pd.read_csv(csv_file)
+
+        # 仅该 split
+        df = df[df[split_col].astype(str).str.lower() == str(split).lower()]
+
+        # 过滤无标签
+        if ignore_unlabeled:
+            df = df[~df[label_col].isna()]
+            df = df[df[label_col].astype(str).str.len() > 0]
+
+        # 路径存在性检查
+        df[path_col] = df[path_col].astype(str)
+        df["__exists__"] = df[path_col].apply(lambda p: Path(p).is_file())
+        missing = (~df["__exists__"]).sum()
+        if missing > 0:
+            print(f"[WARN] {missing} files not found; dropped. Example: "
+                  f"{df.loc[~df['__exists__'], path_col].head(3).tolist()}")
+        df = df[df["__exists__"]].copy()
+
+        # 标签归一：数字/浮点转 int，其他保留 str
+        def norm_label(v):
+            try:
+                return int(float(v))
+            except Exception:
+                return str(v)
+        df["__y__"] = df[label_col].apply(norm_label)
+
+        # 类别映射（未指定则按该 split 构建；真正训练会用 train 的映射对齐）
+        if class_to_idx is None:
+            uniq = df["__y__"].unique().tolist()
+            nums = sorted([u for u in uniq if isinstance(u, int)])
+            strs = sorted([u for u in uniq if isinstance(u, str)])
+            classes = nums + strs
+            class_to_idx = {c: i for i, c in enumerate(classes)}
+
+        self.class_to_idx = class_to_idx
+        self.idx_to_class = {v: k for k, v in class_to_idx.items()}
+
+        # 样本列表
+        self.samples = []
+        for _, r in df.iterrows():
+            y = r["__y__"]
+            if y not in self.class_to_idx:
+                continue
+            self.samples.append((r[path_col], self.class_to_idx[y]))
+
+        self._report()
+
+    def _report(self):
+        print(f"[INFO] Loaded {len(self.samples)} samples for split.")
+        counter = Counter([y for _, y in self.samples])
+        if len(counter) > 0:
+            pretty = ", ".join([f"{self.idx_to_class[k]}({k}):{v}" for k, v in sorted(counter.items())])
+            print(f"[INFO] Class histogram: {pretty}")
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, idx):
+        path, target = self.samples[idx]
+        with Image.open(path) as img:
+            img = img.convert("RGB")
+        if self.transform is not None:
+            img = self.transform(img)
+        return img, target
+
+    def get_class_counts(self):
+        """返回各类别的样本数量，用于计算权重"""
+        counter = Counter([y for _, y in self.samples])
+        counts = [0] * len(self.class_to_idx)
+        for class_idx, count in counter.items():
+            counts[class_idx] = count
+        return counts
+
+
+def build_transforms(args):
+    # 没有 --norm 时回退 IMAGENET
+    norm_name = getattr(args, "norm", "IMAGENET")
+    mean_std = {
+        "IMAGENET": ((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)),
+    }
+    mean, std = mean_std.get(str(norm_name).upper(), mean_std["IMAGENET"])
+
+    train_tf = create_transform(
+        input_size=args.input_size, is_training=True,
+        color_jitter=args.color_jitter,
+        auto_augment=args.aa if args.aa and args.aa.lower() != "none" else None,
+        interpolation="bicubic",
+        re_prob=args.reprob, re_mode=args.remode, re_count=args.recount,
+        mean=mean, std=std,
+    )
+    eval_tf = create_transform(
+        input_size=args.input_size, is_training=False,
+        interpolation="bicubic", mean=mean, std=std,
+    )
+    return train_tf, eval_tf
+
+
+# =========================
+# 训练（支持单卡/多卡 + 梯度累积）
+# =========================
+def train_one_epoch(
+    model, criterion, data_loader, optimizer, device, epoch, loss_scaler,
+    clip_grad=None, mixup_fn=None, log_writer=None, args=None
+):
+    model.train(True)
+    header = f"Epoch[{epoch}]"
+    num_steps = len(data_loader)
+    running_loss = 0.0
+
+    optimizer.zero_grad(set_to_none=True)
+    accum_iter = max(1, int(args.accum_iter))
+
+    # DDP 情况下，确保每个 epoch 刷新 shuffle
+    if isinstance(getattr(data_loader, "sampler", None), DistributedSampler):
+        data_loader.sampler.set_epoch(epoch)
+
+    for step, (images, targets) in enumerate(data_loader):
+        images = images.to(device, non_blocking=True)
+        targets = targets.to(device, non_blocking=True)
+
+        if mixup_fn is not None:
+            images, targets = mixup_fn(images, targets)
+
+        with autocast_context(enabled=True, dtype=torch.bfloat16):
+            outputs = model(images)
+            loss = criterion(outputs, targets)
+            loss = loss / accum_iter  # 累积时缩放
+
+        loss_value = loss.item() * accum_iter
+        running_loss += loss_value
+
+        grad_update = ((step + 1) % accum_iter == 0) or (step + 1 == num_steps)
+        loss_scaler(
+            loss, optimizer, clip_grad=clip_grad, parameters=model.parameters(),
+            create_graph=False, update_grad=grad_update
+        )
+        if grad_update:
+            optimizer.zero_grad(set_to_none=True)
+
+        if (step % 50 == 0) or (step + 1 == num_steps):
+            lr = optimizer.param_groups[0]["lr"]
+            if misc.is_main_process():
+                print(f"{header} [{step+1:>5d}/{num_steps}] loss={loss_value:.4f} lr={lr:.2e}")
+
+    # 进程间取平均（可选；这里只在主进程记录）
+    epoch_loss = running_loss / max(1, num_steps)
+    if log_writer is not None and misc.is_main_process():
+        log_writer.add_scalar("loss/train", epoch_loss, epoch)
+        log_writer.add_scalar("lr", optimizer.param_groups[0]["lr"], epoch)
+    return {"loss": epoch_loss}
+
+
+def get_args_parser():
+    parser = argparse.ArgumentParser(
+        "RETFound DINOv2 fine-tuning (single/multi-GPU, CSV with absolute paths)", add_help=False
+    )
+    # Core（适配 10–20k 图像微调）
+    parser.add_argument("--batch_size", default=64, type=int,
+                        help="Per-GPU batch size (effective = batch_size * accum_iter * world_size)")
+    parser.add_argument("--epochs", default=30, type=int)
+    parser.add_argument("--accum_iter", default=2, type=int, help="Gradient accumulation steps")
+
+    # Model
+    parser.add_argument("--model", default="RETFound_dinov2", type=str,
+                        help="RETFound_dinov2 / RETFound_mae / Dinov2 / Dinov3 ...")
+    parser.add_argument("--model_arch", default="dinov2_vitb14", type=str)
+    parser.add_argument("--input_size", default=256, type=int)
+    parser.add_argument("--drop_path", type=float, default=0.2)
+    parser.add_argument("--global_pool", action="store_true"); parser.set_defaults(global_pool=True)
+    parser.add_argument("--cls_token", action="store_false", dest="global_pool")
+
+    # Optim / schedule
+    parser.add_argument("--clip_grad", type=float, default=None)
+    parser.add_argument("--weight_decay", type=float, default=0.05)
+    parser.add_argument("--lr", type=float, default=None,
+                        help="If None, lr = blr * (batch_size*accum_iter*world_size)/256")
+    parser.add_argument("--blr", type=float, default=2e-3,
+                        help="base lr; lr = blr * (batch_size*accum_iter*world_size)/256")
+    parser.add_argument("--layer_decay", type=float, default=0.65)
+    parser.add_argument("--min_lr", type=float, default=1e-6)
+    parser.add_argument("--warmup_epochs", type=int, default=5)
+
+    # Aug
+    parser.add_argument("--color_jitter", type=float, default=None)
+    parser.add_argument("--aa", type=str, default="rand-m9-mstd0.5-inc1")
+    parser.add_argument("--smoothing", type=float, default=0.0)  # 改为0.0，避免伤害少数类
+    parser.add_argument("--reprob", type=float, default=0.25)
+    parser.add_argument("--remode", type=str, default="pixel")
+    parser.add_argument("--recount", type=int, default=1)
+
+    # Mixup/Cutmix（默认关；若开请改用 SoftTargetCrossEntropy）
+    parser.add_argument("--mixup", type=float, default=0.0)
+    parser.add_argument("--cutmix", type=float, default=0.0)
+    parser.add_argument("--cutmix_minmax", type=float, nargs="+", default=None)
+    parser.add_argument("--mixup_prob", type=float, default=1.0)
+    parser.add_argument("--mixup_switch_prob", type=float, default=0.5)
+    parser.add_argument("--mixup_mode", type=str, default="batch")
+
+    # Finetune
+    parser.add_argument("--finetune", default="RETFound_dinov2", type=str,
+                        help="RETFound_dinov2 / RETFound_mae will be downloaded from HF")
+    parser.add_argument("--task", default="csv_paths_run", type=str)
+    parser.add_argument("--adaptation", default="finetune", choices=["finetune", "lp"])
+
+    # CSV columns
+    parser.add_argument("--csv_file", type=str, required=True)
+    parser.add_argument("--path_col", type=str, default="path",
+                        help="column name for absolute image path")
+    parser.add_argument("--label_col", type=str, default="partition",
+                        help="label column name (e.g., eye_history or partition)")
+    parser.add_argument("--split_col", type=str, default="split",
+                        help="column that has train/iv/ev")
+    parser.add_argument("--ignore_unlabeled", action="store_true", default=True,
+                        help="drop rows with empty/NaN label")
+
+    # Runtime & IO
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--seed", default=0, type=int)
+    parser.add_argument("--resume", default="")
+    parser.add_argument("--start_epoch", default=0, type=int)
+    parser.add_argument("--eval", action="store_true")
+    parser.add_argument("--num_workers", default=8, type=int)
+    parser.add_argument("--pin_mem", action="store_true"); parser.set_defaults(pin_mem=True)
+    parser.add_argument("--output_dir", default="./output_dir")
+    parser.add_argument("--log_dir", default="./output_logs")
+    parser.add_argument("--savemodel", action="store_true", default=True)
+
+    # 分布式参数（按 util.misc 的约定）
+    parser.add_argument("--world_size", default=1, type=int)
+    parser.add_argument("--local_rank", default=-1, type=int)
+    parser.add_argument("--dist_on_itp", action="store_true")
+    parser.add_argument("--dist_url", default="env://")
+    parser.add_argument("--dist_eval", action="store_true", default=False,
+                        help="use DistributedSampler for val/test")
+
+    # 归一化 preset
+    parser.add_argument("--norm", default="IMAGENET", type=str,
+                        help="Normalization preset, default IMAGENET")
+
+    # 可选：手动覆盖类别数（否则从 train 推断）
+    parser.add_argument("--nb_classes", type=int, default=None,
+                        help="override class count (otherwise infer from train split)")
+
+    # 类别权重和采样相关参数
+    parser.add_argument("--use_class_weights", action="store_true", default=True,
+                        help="use class weights in CrossEntropyLoss")
+    parser.add_argument("--use_weighted_sampler", action="store_true", default=True,
+                        help="use WeightedRandomSampler for training")
+
+    # Optuna tuning
+    parser.add_argument("--optuna_trials", type=int, default=0,
+                        help="number of Optuna trials (0 to disable)")
+    parser.add_argument("--optuna_timeout", type=int, default=None,
+                        help="overall Optuna timeout in seconds")
+    parser.add_argument("--optuna_direction", type=str, default="maximize",
+                        help="study direction, typically maximize validation score")
+    parser.add_argument("--optuna_storage", type=str, default=None,
+                        help="Optuna storage URL for persistent studies")
+    parser.add_argument("--optuna_study_name", type=str, default=None,
+                        help="Optuna study name")
+    parser.add_argument("--optuna_resume", action="store_true", default=False,
+                        help="resume Optuna study if it already exists")
+    parser.add_argument("--optuna_seed", type=int, default=None,
+                        help="random seed for Optuna sampler")
+    parser.add_argument("--optuna_pruner", type=str, default="none",
+                        help="pruner type: none or median")
+    parser.add_argument("--optuna_epochs", type=int, default=None,
+                        help="override training epochs during Optuna trials")
+    parser.add_argument("--optuna_eval_test", action="store_true", default=False,
+                        help="run test evaluation inside Optuna trials")
+    parser.add_argument("--optuna_n_jobs", type=int, default=1,
+                        help="number of parallel Optuna jobs")
+    parser.add_argument("--optuna_sampler", type=str, default="tpe",
+                        help="sampler to use: tpe or random")
+
+    return parser
+
+
+def run_experiment(args: argparse.Namespace, trial: Optional["optuna.trial.Trial"] = None) -> float:
+    # 由 util.misc 自动设置 args.distributed / args.gpu / ranks
+    misc.init_distributed_mode(args)
+    device = torch.device(args.device)
+
+    if misc.is_main_process():
+        print(f"job dir: {os.path.dirname(os.path.realpath(__file__))}")
+        print(f"{args}".replace(", ", ",\n"))
+        if trial is not None:
+            print(f"[Optuna] Running trial #{trial.number}")
+
+    if trial is not None:
+        args.blr = trial.suggest_float("blr", 5e-4, 5e-3, log=True)
+        args.weight_decay = trial.suggest_float("weight_decay", 1e-6, 5e-2, log=True)
+        args.drop_path = trial.suggest_float("drop_path", 0.0, 0.4)
+        args.layer_decay = trial.suggest_float("layer_decay", 0.5, 0.9)
+        args.smoothing = trial.suggest_float("smoothing", 0.0, 0.15)
+        args.accum_iter = trial.suggest_categorical("accum_iter", [1, 2])
+        args.use_class_weights = trial.suggest_categorical("use_class_weights", [True, False])
+        args.use_weighted_sampler = trial.suggest_categorical("use_weighted_sampler", [True, False])
+        args.lr = None
+
+    # DDP 建议：多卡时固定本地设备
+    if args.distributed and torch.cuda.is_available():
+        torch.cuda.set_device(args.gpu)
+
+    torch.manual_seed(args.seed + misc.get_rank())
+    np.random.seed(args.seed + misc.get_rank())
+    cudnn.benchmark = True
+
+    start_time = time.time()
+    max_score = float("-inf")
+    best_epoch = 0
+    log_writer: Optional[SummaryWriter] = None
+
+    try:
+        # ====== 数据与类别数（先于建模，以便确定 nb_classes）======
+        train_tf, eval_tf = build_transforms(args)
+
+        tmp_train = CSVDataset(
+            args.csv_file, split="train",
+            path_col=args.path_col, label_col=args.label_col, split_col=args.split_col,
+            transform=train_tf, ignore_unlabeled=args.ignore_unlabeled, class_to_idx=None
+        )
+        class_to_idx = tmp_train.class_to_idx
+        inferred_num_classes = len(class_to_idx)
+        if args.nb_classes is None:
+            args.nb_classes = inferred_num_classes
+            if misc.is_main_process():
+                print(f"[INFO] nb_classes inferred from train split: {args.nb_classes}")
+        elif args.nb_classes != inferred_num_classes and misc.is_main_process():
+            print(f"[WARN] nb_classes ({args.nb_classes}) != inferred ({inferred_num_classes}); "
+                  f"proceeding with nb_classes={args.nb_classes}")
+
+        dataset_train = tmp_train
+        dataset_val = CSVDataset(
+            args.csv_file, split="iv",
+            path_col=args.path_col, label_col=args.label_col, split_col=args.split_col,
+            transform=eval_tf, ignore_unlabeled=args.ignore_unlabeled, class_to_idx=class_to_idx
+        )
+        dataset_test = CSVDataset(
+            args.csv_file, split="ev",
+            path_col=args.path_col, label_col=args.label_col, split_col=args.split_col,
+            transform=eval_tf, ignore_unlabeled=args.ignore_unlabeled, class_to_idx=class_to_idx
+        )
+
+        # ====== 计算类别权重 ======
+        if args.use_class_weights:
+            class_counts = dataset_train.get_class_counts()
+            counts_tensor = torch.tensor(class_counts, dtype=torch.float32)
+            denom = counts_tensor.clamp_min(1.0)
+            class_weights = (counts_tensor.sum() / (len(counts_tensor) * denom)).to(device)
+            if misc.is_main_process():
+                print(f"[INFO] Class counts: {class_counts}")
+                print(f"[INFO] Class weights: {class_weights.cpu().tolist()}")
+            criterion: torch.nn.Module = torch.nn.CrossEntropyLoss(
+                weight=class_weights, label_smoothing=args.smoothing
+            )
+        else:
+            criterion = torch.nn.CrossEntropyLoss(label_smoothing=args.smoothing)
+
+        # ====== 模型 ======
+        if args.model == "RETFound_mae":
+            model = models.__dict__[args.model](
+                img_size=args.input_size, num_classes=args.nb_classes,
+                drop_path_rate=args.drop_path, global_pool=args.global_pool,
+            )
+        else:
+            model = models.__dict__[args.model](
+                num_classes=args.nb_classes, drop_path_rate=args.drop_path, args=args,
+            )
+
+        # 预训练权重
+        if args.finetune and not args.eval:
+            if misc.is_main_process():
+                print(f"[Load Pretrain] {args.finetune}")
+            if args.model in ["Dinov3", "Dinov2"]:
+                checkpoint_path = args.finetune
+            elif args.model in ["RETFound_dinov2", "RETFound_mae"]:
+                checkpoint_path = hf_hub_download(
+                    repo_id=f"YukunZhou/{args.finetune}",
+                    filename=f"{args.finetune}.pth",
+                )
+            else:
+                raise ValueError("Unsupported model for finetuning")
+
+            checkpoint = torch.load(checkpoint_path, map_location="cpu")
+            if args.model in ["Dinov3", "Dinov2"]:
+                checkpoint_model = checkpoint
+            elif args.model == "RETFound_dinov2":
+                checkpoint_model = checkpoint["teacher"]
+            else:
+                checkpoint_model = checkpoint["model"]
+
+            ckpt = {k.replace("backbone.", ""): v for k, v in checkpoint_model.items()}
+            ckpt = {k.replace("mlp.w12.", "mlp.fc1."): v for k, v in ckpt.items()}
+            ckpt = {k.replace("mlp.w3.", "mlp.fc2."): v for k, v in ckpt.items()}
+
+            # 删除不匹配的分类头
+            state_dict = model.state_dict()
+            for k in ["head.weight", "head.bias"]:
+                if k in ckpt and ckpt[k].shape != state_dict[k].shape:
+                    if misc.is_main_process():
+                        print(f"[Pretrain] remove {k}")
+                    del ckpt[k]
+
+            interpolate_pos_embed(model, ckpt)
+            _ = model.load_state_dict(ckpt, strict=False)
+
+            # 重新初始化分类头
+            if hasattr(model, "head") and hasattr(model.head, "weight"):
+                trunc_normal_(model.head.weight, std=2e-5)
+                if getattr(model.head, "bias", None) is not None:
+                    torch.nn.init.zeros_(model.head.bias)
+
+        # ====== DDP 包装（如启用）
+        model.to(device)
+        model_without_ddp = model
+        if args.distributed:
+            ddp_kwargs = dict(broadcast_buffers=False)
+            if args.adaptation == "lp":
+                ddp_kwargs["find_unused_parameters"] = True
+            model = torch.nn.parallel.DistributedDataParallel(
+                model, device_ids=[args.gpu] if torch.cuda.is_available() else None, **ddp_kwargs
+            )
+            model_without_ddp = model.module
+
+        # ====== Sampler / DataLoader（单/多卡）======
+        if args.distributed:
+            sampler_train = DistributedSampler(
+                dataset_train, num_replicas=misc.get_world_size(), rank=misc.get_rank(), shuffle=True
+            )
+            if misc.is_main_process():
+                print("[INFO] Using DistributedSampler for training (WeightedRandomSampler disabled in distributed mode)")
+            if args.dist_eval:
+                sampler_val = DistributedSampler(dataset_val, shuffle=False)
+                sampler_test = DistributedSampler(dataset_test, shuffle=False)
+            else:
+                sampler_val = SequentialSampler(dataset_val)
+                sampler_test = SequentialSampler(dataset_test)
+        else:
+            if args.use_weighted_sampler:
+                class_counts = dataset_train.get_class_counts()
+                sample_weights = []
+                for _, target in dataset_train.samples:
+                    sample_weights.append(1.0 / max(class_counts[target], 1))
+
+                sampler_train = WeightedRandomSampler(
+                    weights=sample_weights,
+                    num_samples=len(sample_weights),
+                    replacement=True
+                )
+                if misc.is_main_process():
+                    print("[INFO] Using WeightedRandomSampler for training")
+            else:
+                sampler_train = RandomSampler(dataset_train)
+                if misc.is_main_process():
+                    print("[INFO] Using RandomSampler for training")
+
+            sampler_val = SequentialSampler(dataset_val)
+            sampler_test = SequentialSampler(dataset_test)
+
+        if misc.is_main_process() and (not args.eval):
+            os.makedirs(args.log_dir, exist_ok=True)
+            log_writer = SummaryWriter(log_dir=os.path.join(args.log_dir, args.task))
+
+        data_loader_train = torch.utils.data.DataLoader(
+            dataset_train, sampler=sampler_train, batch_size=args.batch_size,
+            num_workers=args.num_workers, pin_memory=args.pin_mem, drop_last=True
+        )
+        if misc.is_main_process():
+            print(f"[INFO] len(train_set)={len(dataset_train)} (batches: {len(data_loader_train)})")
+
+        data_loader_val = torch.utils.data.DataLoader(
+            dataset_val, sampler=sampler_val, batch_size=args.batch_size,
+            num_workers=args.num_workers, pin_memory=args.pin_mem, drop_last=False
+        )
+        data_loader_test = torch.utils.data.DataLoader(
+            dataset_test, sampler=sampler_test, batch_size=args.batch_size,
+            num_workers=args.num_workers, pin_memory=args.pin_mem, drop_last=False
+        )
+
+        # Mixup/Cutmix
+        mixup_fn = None
+        mixup_active = (args.mixup > 0) or (args.cutmix > 0.) or (args.cutmix_minmax is not None)
+        if mixup_active:
+            if misc.is_main_process():
+                print("[INFO] Mixup activated")
+            mixup_fn = Mixup(
+                mixup_alpha=args.mixup, cutmix_alpha=args.cutmix, cutmix_minmax=args.cutmix_minmax,
+                prob=args.mixup_prob, switch_prob=args.mixup_switch_prob, mode=args.mixup_mode,
+                label_smoothing=args.smoothing, num_classes=args.nb_classes
+            )
+            criterion = SoftTargetCrossEntropy()
+
+        # Eval-only resume
+        if args.resume and args.eval:
+            checkpoint = torch.load(args.resume, map_location="cpu")
+            if misc.is_main_process():
+                print(f"[Eval] Load checkpoint: {args.resume}")
+            model_without_ddp.load_state_dict(checkpoint["model"])
+
+        if args.adaptation == "lp":
+            for name, p in model_without_ddp.named_parameters():
+                p.requires_grad = ("head" in name)
+            if misc.is_main_process():
+                print("[Adaptation] Linear probe: train head only.")
+        else:
+            if misc.is_main_process():
+                print("[Adaptation] Full finetune.")
+
+        n_parameters = sum(p.numel() for p in model_without_ddp.parameters() if p.requires_grad)
+        if misc.is_main_process():
+            print(f"[INFO] Trainable params (M): {n_parameters/1e6:.2f}")
+
+        world_size = misc.get_world_size()
+        eff_bs = args.batch_size * args.accum_iter * world_size
+        if args.lr is None:
+            args.lr = args.blr * eff_bs / 256
+        if misc.is_main_process():
+            print(f"base lr: {args.blr:.2e}  actual lr: {args.lr:.2e}  accum_iter: {args.accum_iter}  "
+                  f"world_size: {world_size}  eff_bs: {eff_bs}")
+
+        no_weight_decay = (model_without_ddp.no_weight_decay() if hasattr(model_without_ddp, "no_weight_decay") else [])
+        param_groups = lrd.param_groups_lrd(
+            model_without_ddp, weight_decay=args.weight_decay,
+            no_weight_decay_list=no_weight_decay, layer_decay=args.layer_decay,
+        )
+        for g in param_groups:
+            g["params"] = [p for p in g["params"] if p.requires_grad]
+        optimizer = torch.optim.AdamW(param_groups, lr=args.lr)
+        loss_scaler = NativeScaler()
+        if misc.is_main_process():
+            print(f"criterion = {criterion}")
+
+        misc.load_model(args=args, model_without_ddp=model_without_ddp,
+                        optimizer=optimizer, loss_scaler=loss_scaler)
+
+        if args.eval:
+            if "checkpoint" in locals() and isinstance(checkpoint, dict) and ("epoch" in checkpoint):
+                if misc.is_main_process():
+                    print(f"[Eval] best epoch = {checkpoint['epoch']}")
+            _test_stats, _auc_roc = evaluate(
+                data_loader_test, model, device, args, epoch=0, mode="test",
+                num_class=args.nb_classes, log_writer=log_writer
+            )
+            if log_writer is not None:
+                log_writer.flush()
+                log_writer.close()
+            return _auc_roc
+
+        if misc.is_main_process():
+            desc = f"Trial {trial.number}" if trial is not None else "Epochs"
+            epoch_iter = tqdm(range(args.start_epoch, args.epochs), desc=desc)
+        else:
+            epoch_iter = range(args.start_epoch, args.epochs)
+
+        for epoch in epoch_iter:
+            train_stats = train_one_epoch(
+                model, criterion, data_loader_train,
+                optimizer, device, epoch, loss_scaler,
+                clip_grad=args.clip_grad, mixup_fn=mixup_fn,
+                log_writer=log_writer, args=args
+            )
+
+            val_stats, val_score = evaluate(
+                data_loader_val, model, device, args, epoch, mode="val",
+                num_class=args.nb_classes, log_writer=log_writer
+            )
+
+            if trial is not None:
+                trial.report(val_score, epoch)
+                if trial.should_prune():
+                    if log_writer is not None:
+                        log_writer.flush()
+                        log_writer.close()
+                    raise optuna.TrialPruned()  # type: ignore[misc]
+
+            if misc.is_main_process():
+                if max_score < val_score:
+                    max_score = val_score
+                    best_epoch = epoch
+                    if args.output_dir and args.savemodel:
+                        misc.save_model(
+                            args=args, model=model, model_without_ddp=model_without_ddp,
+                            optimizer=optimizer, loss_scaler=loss_scaler, epoch=epoch, mode="best"
+                        )
+                print(f"[VAL] Best epoch={best_epoch}, Best score={max_score:.4f}")
+
+                if log_writer is not None:
+                    log_writer.add_scalar("loss/val", val_stats["loss"], epoch)
+                    log_writer.flush()
+
+                log_stats = {**{f"train_{k}": v for k, v in train_stats.items()},
+                             "epoch": epoch, "n_parameters": n_parameters}
+                if args.output_dir:
+                    os.makedirs(os.path.join(args.output_dir, args.task), exist_ok=True)
+                    with open(os.path.join(args.output_dir, args.task, "log.txt"), "a", encoding="utf-8") as f:
+                        f.write(json.dumps(log_stats) + "\n")
+
+            if args.distributed:
+                torch.distributed.barrier()
+
+        if log_writer is not None:
+            log_writer.flush()
+            log_writer.close()
+
+        if trial is None or args.optuna_eval_test:
+            ckpt_path = os.path.join(args.output_dir, args.task, "checkpoint-best.pth")
+            if args.savemodel and os.path.isfile(ckpt_path):
+                if misc.is_main_process():
+                    print(f"[TEST] Loading best checkpoint from {ckpt_path}")
+                checkpoint = torch.load(ckpt_path, map_location="cpu")
+                model_without_ddp.load_state_dict(checkpoint["model"], strict=False)
+                model.to(device)
+                if misc.is_main_process():
+                    print(f"[TEST] best epoch = {checkpoint.get('epoch', -1)}")
+            if args.distributed:
+                for p in model.parameters():
+                    torch.distributed.broadcast(p.data, src=0)
+
+            _test_stats, _auc_roc = evaluate(
+                data_loader_test, model, device, args, -1, mode="test",
+                num_class=args.nb_classes, log_writer=None
+            )
+            if trial is None and misc.is_main_process():
+                total_time = time.time() - start_time
+                total_time_str = str(datetime.timedelta(seconds=int(total_time)))
+                print(f"Training time {total_time_str}")
+                print(f"[TEST] score={_auc_roc:.4f}")
+        else:
+            if misc.is_main_process():
+                total_time = time.time() - start_time
+                total_time_str = str(datetime.timedelta(seconds=int(total_time)))
+                print(f"[Optuna][Trial {trial.number}] best score={max_score:.4f} (time={total_time_str})")
+
+        return max_score
+
+    finally:
+        if log_writer is not None:
+            log_writer.flush()
+            log_writer.close()
+        if args.distributed and torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+def _clone_args(args: argparse.Namespace) -> argparse.Namespace:
+    return argparse.Namespace(**vars(args))
+
+
+def run_optuna(args: argparse.Namespace) -> None:
+    if optuna is None:
+        raise ImportError("Optuna is not installed. Please `pip install optuna`.")
+    if args.optuna_trials <= 0:
+        raise ValueError("optuna_trials must be > 0 to start tuning")
+
+    sampler: Optional[optuna.samplers.BaseSampler]
+    if args.optuna_sampler == "random":
+        sampler = optuna.samplers.RandomSampler(seed=args.optuna_seed)
+    else:
+        sampler = optuna.samplers.TPESampler(seed=args.optuna_seed)
+
+    pruner: Optional[optuna.pruners.BasePruner] = None
+    if args.optuna_pruner == "median":
+        pruner = optuna.pruners.MedianPruner()
+
+    study_kwargs = {"direction": args.optuna_direction, "sampler": sampler, "pruner": pruner}
+    if args.optuna_storage:
+        study_kwargs["storage"] = args.optuna_storage
+        if args.optuna_study_name:
+            study_kwargs["study_name"] = args.optuna_study_name
+        study_kwargs["load_if_exists"] = args.optuna_resume
+    elif args.optuna_study_name:
+        study_kwargs["study_name"] = args.optuna_study_name
+
+    study = optuna.create_study(**study_kwargs)
+
+    def objective(trial: "optuna.trial.Trial") -> float:
+        trial_args = _clone_args(args)
+        trial_args.optuna_trials = 0
+        trial_args.optuna_timeout = None
+        trial_args.optuna_n_jobs = 1
+        trial_args.optuna_direction = args.optuna_direction
+        trial_args.optuna_pruner = args.optuna_pruner
+        trial_args.optuna_sampler = args.optuna_sampler
+        trial_args.optuna_eval_test = args.optuna_eval_test
+        trial_args.task = f"{args.task}_trial{trial.number:04d}"
+        if args.optuna_epochs is not None:
+            trial_args.epochs = args.optuna_epochs
+        trial_args.start_epoch = 0
+        trial_args.resume = ""
+        trial_args.savemodel = bool(args.optuna_eval_test)
+        base_output = Path(args.output_dir)
+        base_output.mkdir(parents=True, exist_ok=True)
+        (Path(args.log_dir)).mkdir(parents=True, exist_ok=True)
+        return run_experiment(trial_args, trial)
+
+    study.optimize(
+        objective,
+        n_trials=args.optuna_trials,
+        timeout=args.optuna_timeout,
+        n_jobs=args.optuna_n_jobs,
+        gc_after_trial=True,
+    )
+
+    if len(study.trials) == 0:
+        return
+
+    if study.best_trial is not None:
+        if optuna.study.StudyDirection.MAXIMIZE == study.direction:
+            direction_str = "maximize"
+        else:
+            direction_str = "minimize"
+        print(f"[Optuna] Best trial #{study.best_trial.number} {direction_str} value={study.best_value:.4f}")
+        print("[Optuna] Best parameters:")
+        for k, v in study.best_trial.params.items():
+            print(f"    {k}: {v}")
+
+        summary_path = Path(args.output_dir) / args.task / "optuna_best.json"
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(summary_path, "w", encoding="utf-8") as fp:
+            json.dump({
+                "value": study.best_value,
+                "params": study.best_trial.params,
+                "direction": args.optuna_direction,
+                "datetime": datetime.datetime.now().isoformat(),
+            }, fp, ensure_ascii=False, indent=2)
+
+
+def main(args: argparse.Namespace) -> None:
+    if args.optuna_trials and args.optuna_trials > 0:
+        run_optuna(args)
+    else:
+        run_experiment(args)
+
+
+if __name__ == "__main__":
+    args = get_args_parser()
+    args = args.parse_args()
+
+    if args.output_dir and (not os.path.exists(args.output_dir)):
+        Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+
+    main(args)


### PR DESCRIPTION
## Summary
- add optional Optuna dependency and CLI switches to the multi-GPU classification entrypoint
- refactor the training routine into a reusable experiment runner with trial-aware logging and mixup-safe losses
- provide an Optuna study driver that saves the best hyperparameters for later reuse

## Testing
- python -m py_compile 微调RETFound 多卡分类任务.py

------
https://chatgpt.com/codex/tasks/task_e_68e367738a688330b91ecfeb23bf551f